### PR TITLE
deprecate check_max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.3.1 - 2025-09-06
+
+### `Fixed`
+- deprecated check_max that stopped working on cirro
+
 ## v1.3.0 - 2025-08-28
 
 ### `Added`

--- a/conf/base.config
+++ b/conf/base.config
@@ -11,9 +11,11 @@
 process {
 
     // TODO nf-core: Check the defaults for all processes
-    cpus   = { check_max( 1    * task.attempt, 'cpus'   ) }
-    memory = { check_max( 6.GB * task.attempt, 'memory' ) }
-    time   = { check_max( 4.h  * task.attempt, 'time'   ) }
+    cpus   = { 1    * task.attempt }
+    memory = { 6.GB * task.attempt }
+    time   = { 4.h  * task.attempt }
+
+    resourceLimits = [ cpus: params.max_cpus, memory: params.max_memory, time: params.max_time ]
 
     errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
     maxRetries    = 1
@@ -27,30 +29,30 @@ process {
     // TODO nf-core: Customise requirements for specific processes.
     // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel:process_single {
-        cpus   = { check_max( 1                  , 'cpus'    ) }
-        memory = { check_max( 6.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 4.h  * task.attempt, 'time'    ) }
+        cpus   = {1                   }
+        memory = {6.GB * task.attempt }
+        time   = {4.h  * task.attempt }
     }
     withLabel:process_low {
-        cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 4.h   * task.attempt, 'time'    ) }
+        cpus   = {2     * task.attempt }
+        memory = {12.GB * task.attempt }
+        time   = {4.h   * task.attempt }
     }
     withLabel:process_medium {
-        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+        cpus   = {6     * task.attempt }
+        memory = {36.GB * task.attempt }
+        time   = {8.h   * task.attempt }
     }
     withLabel:process_high {
-        cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
-        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+        cpus   = {12    * task.attempt }
+        memory = {72.GB * task.attempt }
+        time   = {16.h  * task.attempt }
     }
     withLabel:process_long {
-        time   = { check_max( 20.h  * task.attempt, 'time'    ) }
+        time   = {20.h  * task.attempt }
     }
     withLabel:process_high_memory {
-        memory = { check_max( 200.GB * task.attempt, 'memory' ) }
+        memory = {200.GB * task.attempt}
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'
@@ -60,39 +62,6 @@ process {
         maxRetries    = 2
     }
     withName: 'BAYESTME_FILTER_GENES' {
-        memory = { check_max( 24.GB * task.attempt, 'memory' ) }
-    }
-}
-
-// Function to ensure that resource requirements don't go beyond
-// a maximum limit
-def check_max(obj, type) {
-    if (type == 'memory') {
-        try {
-            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-                return params.max_memory as nextflow.util.MemoryUnit
-            else
-                return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
-            return obj
-        }
-    } else if (type == 'time') {
-        try {
-            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-                return params.max_time as nextflow.util.Duration
-            else
-                return obj
-        } catch (all) {
-            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
-            return obj
-        }
-    } else if (type == 'cpus') {
-        try {
-            return Math.min( obj, params.max_cpus as int )
-        } catch (all) {
-            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
-            return obj
-        }
+        memory = {24.GB * task.attempt}
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -258,7 +258,7 @@ manifest {
     description     = """BTC spatial pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.3.0'
+    version         = '1.3.1'
     doi             = ''
 }
 


### PR DESCRIPTION
there is a [new cleaner way](https://www.nextflow.io/docs/latest/reference/process.html?__hstc=133515217.755cd1ea54ff81896fd7b281f5ff400b.1753205119591.1754399362891.1757159912963.8&__hssc=133515217.2.1757159912963&__hsfp=2512043010&_gl=1*4gim01*_gcl_aw*R0NMLjE3NTQzOTkzNjAuQ2owS0NRancxOGJFQmhDQkFSSXNBS3VBRkVZVUZsbWFmeGZXZWhkNnE1MDBSb01tcGdlbnpoMktRdTZJM2tEQ0RvMWNncHFEaEdhZFNhOGFBdjdFRUFMd193Y0I.*_gcl_au*NDE0MzczODUzLjE3NTMyMDUxMTk.#resourcelimits) to specify max resources 