### PR TITLE
check if a cell type present in neighbors report

### DIFF
--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -113,14 +113,17 @@ def neighbors_report(adatas, spotlight=None):
         sample_dict = {}
         for adata in adatas:
             if "cell_type_interactions" in adata.uns:
-                adata_cell_type_index = adata.obs['cell_type'].cat.categories.get_loc(cell_type)
-                interactions = adata.uns["cell_type_interactions"][adata_cell_type_index]
-                #construct dict of other cell types and interaction values
-                other_cell_types = adata.obs['cell_type'].cat.categories.tolist()
-                interaction_dict = {}
-                for i, other_cell_type in enumerate(other_cell_types):
-                    interaction_dict[other_cell_type] = interactions[i]
-                sample_dict[adata.obs['id'].unique()[0]] = interaction_dict
+                if cell_type not in adata.obs['cell_type'].cat.categories:
+                    continue
+                else:
+                    adata_cell_type_index = adata.obs['cell_type'].cat.categories.get_loc(cell_type)
+                    interactions = adata.uns["cell_type_interactions"][adata_cell_type_index]
+                    #construct dict of other cell types and interaction values
+                    other_cell_types = adata.obs['cell_type'].cat.categories.tolist()
+                    interaction_dict = {}
+                    for i, other_cell_type in enumerate(other_cell_types):
+                        interaction_dict[other_cell_type] = interactions[i]
+                    sample_dict[adata.obs['id'].unique()[0]] = interaction_dict
         reports.append(sample_dict)
 
     mqc_report = {

--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -115,15 +115,14 @@ def neighbors_report(adatas, spotlight=None):
             if "cell_type_interactions" in adata.uns:
                 if cell_type not in adata.obs['cell_type'].cat.categories:
                     continue
-                else:
-                    adata_cell_type_index = adata.obs['cell_type'].cat.categories.get_loc(cell_type)
-                    interactions = adata.uns["cell_type_interactions"][adata_cell_type_index]
-                    #construct dict of other cell types and interaction values
-                    other_cell_types = adata.obs['cell_type'].cat.categories.tolist()
-                    interaction_dict = {}
-                    for i, other_cell_type in enumerate(other_cell_types):
-                        interaction_dict[other_cell_type] = interactions[i]
-                    sample_dict[adata.obs['id'].unique()[0]] = interaction_dict
+                adata_cell_type_index = adata.obs['cell_type'].cat.categories.get_loc(cell_type)
+                interactions = adata.uns["cell_type_interactions"][adata_cell_type_index]
+                #construct dict of other cell types and interaction values
+                other_cell_types = adata.obs['cell_type'].cat.categories.tolist()
+                interaction_dict = {}
+                for i, other_cell_type in enumerate(other_cell_types):
+                    interaction_dict[other_cell_type] = interactions[i]
+                sample_dict[adata.obs['id'].unique()[0]] = interaction_dict
         reports.append(sample_dict)
 
     mqc_report = {

--- a/nextflow.config
+++ b/nextflow.config
@@ -310,7 +310,7 @@ manifest {
     description     = """Spot Transcriptomics Analysis Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '2.2.1'
+    version         = '2.2.2'
     doi             = ''
 }
 


### PR DESCRIPTION
This pull request introduces a small but important fix to the `neighbors_report` function in `xsample.py`. The change ensures that only cell types present in the dataset are processed, which prevents errors when a cell type is missing.

* Logic improvement: Added a check to skip processing for cell types not present in `adata.obs['cell_type'].cat.categories`, ensuring robustness when handling datasets with varying cell types.