### PR TITLE
101 adjust rctd failover doublet mode

### DIFF
--- a/modules/local/rctd/rctd.nf
+++ b/modules/local/rctd/rctd.nf
@@ -7,6 +7,7 @@ process RCTD {
     tuple val(meta), path(adata_sc), path(adata_st)
     output:
     tuple val(meta), path("${prefix}/rctd_cell_types.csv"), emit: rctd_cell_types
+    tuple val(meta), path("${prefix}/rctd.rds"),            emit: rctd_object
     path "versions.yml",                                    emit: versions
 
     script:

--- a/modules/local/rctd/templates/rctd.r
+++ b/modules/local/rctd/templates/rctd.r
@@ -102,7 +102,7 @@ rctd_res <- tryCatch({
                     doublet_mode = doublet_mode)
 }, error = function(e) {
   message('RCTD threw error: "',e[["message"]],'"')
-  if(grep(pattern="UMI_min_sigma", x=e[["message"]])){
+  if (grepl(pattern = "UMI_min_sigma", x = e[["message"]])) {
     message('RCTD error caught, retrying with UMI_min_sigma=1')
     spacexr::run.RCTD(spacexr::create.RCTD(spatialRNA=query, reference=ref, max_cores = ncores, UMI_min_sigma = 1),
                       doublet_mode = doublet_mode)

--- a/modules/local/rctd/templates/rctd.r
+++ b/modules/local/rctd/templates/rctd.r
@@ -105,7 +105,7 @@ rctd_res <- tryCatch({
   if(grep(pattern="UMI_min_sigma", x=e[["message"]])){
     message('RCTD error caught, retrying with UMI_min_sigma=1')
     spacexr::run.RCTD(spacexr::create.RCTD(spatialRNA=query, reference=ref, max_cores = ncores, UMI_min_sigma = 1),
-                      doublet_mode = 'full')
+                      doublet_mode = doublet_mode)
   } else {
     stop("Could not catch the error")
   }
@@ -116,7 +116,10 @@ message('getting cell type deconvolution results')
 cell_types <- spacexr::normalize_weights(rctd_res@results[['weights']])
 message(sprintf('saving results to %s/', outdir))
 dir.create(outdir, showWarnings = FALSE)
+#cell types csv
 write.csv(as.matrix(cell_types), file=file.path(outdir, 'rctd_cell_types.csv'))
+#raw object
+saveRDS(rctd_res, file=file.path(outdir, 'rctd.rds'))
 
 #versions
 message("reading session info")

--- a/nextflow.config
+++ b/nextflow.config
@@ -310,7 +310,7 @@ manifest {
     description     = """Spot Transcriptomics Analysis Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '2.2.3'
+    version         = '2.2.4'
     doi             = ''
 }
 

--- a/tests/modules/local/rctd/rctd.nf.test
+++ b/tests/modules/local/rctd/rctd.nf.test
@@ -3,7 +3,7 @@ nextflow_process {
     script  "modules/local/rctd/rctd.nf"
     process "RCTD"
 
-    test("Should run RCTD deconvolution successfully") {
+    test("Should run RCTD default mode successfully") {
 
         tag "process"
         tag "rctd"
@@ -26,6 +26,36 @@ nextflow_process {
         then {
             assert process.success
             assert process.out.rctd_cell_types
+            assert process.out.rctd_object
+            assert process.out.versions
+        }
+    }
+
+    test("Should run RCTD doublet mode successfully") {
+
+        tag "process"
+        tag "rctd"
+        tag "visiumhd"
+
+        when {
+            params {
+                max_memory = '8.GB'
+                max_cpus   = 2
+                doublet_mode = 'doublet'
+            }
+            process {
+                """
+                input[0] = [[id:"sample"],
+                            file("${projectDir}/tests/data/atlas_small.h5ad"),
+                            file("${projectDir}/tests/data/adata_matched.h5ad")]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.rctd_cell_types
+            assert process.out.rctd_object
             assert process.out.versions
         }
     }


### PR DESCRIPTION
This pull request enhances the RCTD module by introducing the ability to output the full RCTD result object, improves error handling flexibility, and expands test coverage to include doublet mode. The version is also bumped to reflect these changes.

**Feature enhancements:**

* The RCTD Nextflow process now outputs the full RCTD result object as an `.rds` file, in addition to the cell types CSV. This enables downstream analyses that require access to the complete RCTD results. [[1]](diffhunk://#diff-4b819b3831fcc5c3bd128e89d5de6cfddae0d97efb12d9cbe3e7c59eb7c2fec4R10) [[2]](diffhunk://#diff-12b83183fc95473a41470a140d5decb27c0d2247b4b46d97e02deeb9707bb389R119-R122)

**Error handling improvements:**

* The R script now correctly passes the `doublet_mode` parameter when retrying after a "UMI_min_sigma" error, ensuring consistent behavior between normal and retry runs.

**Testing improvements:**

* The test suite adds a new test for RCTD doublet mode, verifying that both the cell types CSV and the RCTD object are produced in this mode.
* The main RCTD test is renamed for clarity and updated to check for the new RCTD object output. [[1]](diffhunk://#diff-435679b3ecd44770d75ef63af4c244ad1b4f551f7e2bd037953998b31bdac4abL6-R6) [[2]](diffhunk://#diff-435679b3ecd44770d75ef63af4c244ad1b4f551f7e2bd037953998b31bdac4abR29-R58)

**Versioning:**

* Pipeline version is incremented from `2.2.3` to `2.2.4` to reflect these updates.