### PR TITLE
136 option to exclude mitochiondrial genes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,8 +27,6 @@ nextflow run https://github.com/break-through-cancer/staple \
   --outdir outs \
   -profile docker
 ```
-# make a clean directory called tests
-mkdir tests
 
 Example terminal output:
 ```

--- a/modules/local/util/main.nf
+++ b/modules/local/util/main.nf
@@ -349,6 +349,23 @@ process ADATA_FROM_SEGMENTED_VISIUM {
     template 'adata_from_segmented_visium.py'
 }
 
+process ADATA_PREPROCESS {
+    //filter genes from an adata file based on a list of genes to keep
+    tag "$meta.id"
+    label "process_medium"
+    container "ghcr.io/break-through-cancer/btc-containers/scverse@sha256:0471909d51c29a5a4cb391ac86f5cf58dad448da7f6862577d206ae8eb831216"
+
+    input:
+        tuple val(meta), path(adata)
+    output:
+        tuple val(meta), path("${prefix}/adata.h5ad"),   emit: adata
+        path("versions.yml"),                            emit: versions
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    template 'adata_preprocess.py'
+}
+
 process ATTACH_CELL_PROBS {
     //attach cell type probabilities to anndata obsm
     tag "$meta.id"

--- a/modules/local/util/main.nf
+++ b/modules/local/util/main.nf
@@ -350,7 +350,7 @@ process ADATA_FROM_SEGMENTED_VISIUM {
 }
 
 process ADATA_PREPROCESS {
-    //filter genes from an adata file based on a list of genes to keep
+    //filter genes from an adata file by dropping genes whose names match a specified prefix (via drop_genes_prefix)
     tag "$meta.id"
     label "process_medium"
     container "ghcr.io/break-through-cancer/btc-containers/scverse@sha256:0471909d51c29a5a4cb391ac86f5cf58dad448da7f6862577d206ae8eb831216"

--- a/modules/local/util/main.nf
+++ b/modules/local/util/main.nf
@@ -178,7 +178,8 @@ sample = "${meta.id}"
 if outname in ["atlas_input", "adata_input", "adata_output"]:
     adata = ad.read_h5ad(adata_path)
     #basic scanpy qc metrics
-    qc = sc.pp.calculate_qc_metrics(adata, inplace=False)
+    adata.var["mito"] = adata.var_names.str.startswith("MT-")
+    qc = sc.pp.calculate_qc_metrics(adata, qc_vars=["mito"], inplace=False)
     report = pd.DataFrame({
         "Sample": [sample],
         "n_genes": adata.shape[1],
@@ -186,6 +187,7 @@ if outname in ["atlas_input", "adata_input", "adata_output"]:
         "mean_genes_by_counts": qc[0]["n_genes_by_counts"].mean(),
         "mean_cells_by_counts": qc[1]["n_cells_by_counts"].mean(),
         "mean_total_nnz_counts": adata.X[adata.X.nonzero()].mean(),
+        "mean_percent_mito": qc[0]["pct_counts_mito"].mean()
     })
     report.to_csv(f"{outname}_report.csv", index=False)
     adata.file.close()

--- a/modules/local/util/templates/adata_preprocess.py
+++ b/modules/local/util/templates/adata_preprocess.py
@@ -9,7 +9,7 @@ adata_path = "${adata}"
 sample = "${meta.id}"
 
 def adata_preprocess(adata, drop_prefix):
-    if "drop_genes_prefix" not in drop_prefix:
+    if drop_prefix:
         adata = adata[:, ~adata.var_names.str.startswith(drop_prefix)]
     adata.file.close()
     return adata

--- a/modules/local/util/templates/adata_preprocess.py
+++ b/modules/local/util/templates/adata_preprocess.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import anndata as ad
+import logging
+import os
+
+drop_prefix = "${params.drop_genes_prefix}"
+adata_path = "${adata}"
+sample = "${meta.id}"
+
+def adata_preprocess(adata, drop_prefix):
+    if "drop_genes_prefix" not in drop_prefix:
+        adata = adata[:, ~adata.var_names.str.startswith(drop_prefix)]
+    adata.file.close()
+    return adata
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger()
+    #output directory
+    os.makedirs(sample, exist_ok=True)
+    
+    adata = ad.read_h5ad(adata_path)
+    log.info(f"Before preprocessing adata: {adata}")
+
+    #preprocess adata
+    adata = adata_preprocess(adata, drop_prefix)
+    
+    #save
+    log.info(f"After preprocessing adata: {adata}")
+    adata.write_h5ad(f"{sample}/adata.h5ad")
+    
+    
+    #versions
+    with open("versions.yml", "w") as f:
+        f.write("${task.process}:\\n")
+        f.write("    anndata: {}\\n".format(ad.__version__))

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,9 @@ params {
     validationShowHiddenParams       = false
     validate_params                  = true
 
+    // preprocessing options
+    drop_genes_prefix                       = false // i.e. "MT-" in gene names
+
     // bayestme internal params
     bayestme_spatial_smoothing_parameter    = 1.0
     reference_scrna_sample_column           = 'donor_id' //that does not exist in bayestme

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,7 +52,7 @@ params {
     validate_params                  = true
 
     // preprocessing options
-    drop_genes_prefix                       = false // i.e. "MT-" in gene names
+    drop_genes_prefix                       = '' // i.e. "MT-" in gene names
 
     // bayestme internal params
     bayestme_spatial_smoothing_parameter    = 1.0

--- a/nextflow.config
+++ b/nextflow.config
@@ -310,7 +310,7 @@ manifest {
     description     = """Spot Transcriptomics Analysis Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '2.2.6'
+    version         = '2.2.7'
     doi             = ''
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -334,6 +334,10 @@
         "good_gene_threshold": {
             "type": "integer",
             "default": 1000
+        },
+        "drop_genes_prefix": {
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -336,8 +336,9 @@
             "default": 1000
         },
         "drop_genes_prefix": {
-            "type": "boolean",
-            "default": false
+            "type": "string",
+            "default": "",
+            "description": "String prefix of gene names to drop (e.g. 'MT-'). Use an empty string to disable dropping by prefix."
         }
     }
 }

--- a/subworkflows/local/load_dataset.nf
+++ b/subworkflows/local/load_dataset.nf
@@ -3,7 +3,8 @@ include { ATLAS_GET;
           ADATA_FROM_VISIUM;
           ADATA_FROM_VISIUM_HD;
           ADATA_FROM_SEGMENTED_VISIUM;
-          ADATA_ADD_METADATA } from '../../modules/local/util/'
+          ADATA_ADD_METADATA;
+          ADATA_PREPROCESS } from '../../modules/local/util/'
 
 
 workflow LOAD_DATASET {
@@ -42,6 +43,15 @@ workflow LOAD_DATASET {
         //report stats after reading
         ch_report = ch_report.mix( ch_raw_adata.map {it -> tuple(it[0], it[1], 'adata_input')} )
 
+        // preprocess
+        if (params.drop_genes_prefix) {
+            ADATA_PREPROCESS( ch_raw_adata )
+            ch_processed_adata = ADATA_PREPROCESS.out.adata
+            versions = versions.mix(ADATA_PREPROCESS.out.versions)
+        } else {
+            ch_processed_adata = ch_raw_adata
+        }
+
         // If an atlas has been provided download and prepare it
         if (params.ref_scrna) {
             ATLAS_GET(params.ref_scrna)
@@ -63,7 +73,7 @@ workflow LOAD_DATASET {
         }
 
         // attach metadata fields for downstream analysis
-        ADATA_ADD_METADATA( ch_raw_adata )
+        ADATA_ADD_METADATA( ch_processed_adata )
         versions = versions.mix(ADATA_ADD_METADATA.out.versions)
         ch_adata = ADATA_ADD_METADATA.out.adata
 

--- a/tests/data/create_adata.nf
+++ b/tests/data/create_adata.nf
@@ -1,0 +1,15 @@
+process CREATE_TEST_ADATA {
+    tag "create_test_adata"
+    label 'process_single'
+    container 'ghcr.io/break-through-cancer/btc-containers/scverse@sha256:0471909d51c29a5a4cb391ac86f5cf58dad448da7f6862577d206ae8eb831216'
+
+    input:
+        val num_adatas
+
+    output:
+        path "*adata.h5ad", emit: adata
+
+    script:
+    template 'create_adata.py'
+
+}

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+import anndata as ad
+import numpy as np
+import pandas as pd
+import squidpy as sq
+
+
+num_adatas = "${num_adatas}"
+
+def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample'):
+
+    # create anndata object n obs by m vars with random counts
+    adata = ad.AnnData(X=np.random.poisson(1, (n, m)), 
+                    obs=pd.DataFrame(index=[f'obs_{i}' for i in range(n)]), 
+                    var=pd.DataFrame(index=[f'var_{j}' for j in range(m)]))
+    #make sparse 
+    adata.X = adata.X.astype(np.float32)
+
+    #mark a percentage of the genes as mitochondrial by name prefix
+    mito_genes = np.random.choice(adata.var_names, size=int(pct_mito*m), replace=False)
+    adata.var_names = ['MT-' + name if name in mito_genes else name for name in adata.var_names]
+
+    # add spatial dimensions to represent a 5x5 grid
+    adata.obsm['spatial'] = np.array([[i // 5, i % 5] for i in range(n)])
+    library_id = 'spatial_data'
+    adata.uns['spatial'] = {
+        library_id: {
+            'scalefactors': {
+                'tissue_hires_scalef': 1.0,
+                'spot_diameter_fullres': 1.0
+            },
+            'images': {}
+        }
+    }
+    sq.gr.spatial_neighbors(adata, spatial_key='spatial')
+
+
+    # add an assignment with all outside cells being stroma surrounding
+    # tumor core and a couple randomly assigned other of type other
+    adata.obs['cell_type'] = 'cancer'
+    outside_indices = [i for i in range(n) if adata.obsm['spatial'][i, 0] in [0, 4] or adata.obsm['spatial'][i, 1] in [0, 4]]
+    for i in outside_indices:
+        adata.obs.at[f'obs_{i}', 'cell_type'] = 'stroma'
+    adata.obs.at[f'obs_{np.random.randint(0,n-1)}', 'cell_type'] = 'other'  # random cell
+    adata.obs.at[f'obs_{np.random.randint(0,n-1)}', 'cell_type'] = 'other'  # another random cell
+    
+    adata.obs['cell_type'] = adata.obs['cell_type'].astype('category')
+    
+    # attach cell type interaction report
+    sq.gr.interaction_matrix(adata, cluster_key='cell_type')
+    
+    # add a random cell type assignment of 3 cel types: tumor, stroma, other
+    cell_types = ['tumor', 'stroma', 'other']
+    adata.obs['cell_type'] = np.random.choice(cell_types, size=n)
+
+    # add sample id for testing
+    adata.obs['id'] = sample_id
+    # add a random response variable for testing
+    adata.obs['response'] = np.random.choice(['responder', 'non-responder'], size=n)
+    
+    #simulate staple behaovior of added metadata from samplesheet
+    adata.uns['added_metadata_fields'] = ['response', 'id']
+
+    return adata
+
+
+def make_many_adata(num_adatas=2, n=25, m=1000, pct_mito=0.1):
+    adatas = []
+    for i in range(num_adatas):
+        adata = make_one_adata(n=n, m=m, pct_mito=pct_mito, sample_id=f'sample_{i}')
+        adatas.append(adata)
+    return adatas
+
+if __name__ == "__main__":
+    adatas = make_many_adata(num_adatas=int(num_adatas), n=25, m=1000, pct_mito=0.1)
+    for i, adata in enumerate(adatas):
+        adata.write_h5ad(f'{i}_adata.h5ad')

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -49,16 +49,17 @@ def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample'):
     # attach cell type interaction report
     sq.gr.interaction_matrix(adata, cluster_key='cell_type')
     
-    # add a random cell type assignment of 3 cel types: tumor, stroma, other
+    # add a random cell type assignment of 3 cell types: tumor, stroma, other
     cell_types = ['tumor', 'stroma', 'other']
     adata.obs['cell_type'] = np.random.choice(cell_types, size=n)
+    adata.obs['cell_type'] = pd.Categorical(adata.obs['cell_type'], categories=cell_types)
 
     # add sample id for testing
     adata.obs['id'] = sample_id
     # add a random response variable for testing
     adata.obs['response'] = np.random.choice(['responder', 'non-responder'], size=n)
     
-    #simulate staple behaovior of added metadata from samplesheet
+    #simulate staple behavior of added metadata from samplesheet
     adata.uns['added_metadata_fields'] = ['response', 'id']
 
     return adata

--- a/tests/modules/local/util/main.nf.test
+++ b/tests/modules/local/util/main.nf.test
@@ -72,3 +72,49 @@ nextflow_process {
         }
     }
 }
+
+nextflow_process {
+    name    "Test Preprocessing"
+    script  "modules/local/util/main.nf"
+    process "ADATA_PREPROCESS"
+
+    setup {
+        run("CREATE_TEST_ADATA") {
+            script "tests/data/create_adata.nf"
+            params {
+                max_cpus = 2
+                max_memory = '4 GB'
+            }
+            process {
+            """
+            input[0] = 2
+            """
+            }
+        }
+    }
+
+    test("Should run ADATA_PREPROCESS successfully with test data") {
+
+        tag "process"
+        tag "preprocess"
+
+        when {
+            params {
+                max_memory = '4.GB'
+                max_cpus   = 1
+                drop_genes_prefix = 'MT-'
+            }
+            
+            process {
+                """
+                input[0] = CREATE_TEST_ADATA.out.adata.map{ it -> [[id:"sample"], it[1]] }
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.versions
+        }
+    }
+}

--- a/tests/modules/local/util/main.nf.test
+++ b/tests/modules/local/util/main.nf.test
@@ -26,3 +26,35 @@ nextflow_process {
         }
     }
 }
+
+nextflow_process {
+    name    "Test QC"
+    script  "modules/local/util/main.nf"
+    process "QC"
+
+    test("Should run QC successfully with local atlas") {
+
+        tag "process"
+        tag "qc"
+
+        when {
+            params {
+                max_memory = '4.GB'
+                max_cpus   = 1
+            }
+            process {
+                """
+                input[0] = [[id:"atlas"],
+                            file("${projectDir}/tests/data/atlas_small.h5ad"),
+                            "atlas_input"]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.versions
+            assert path(process.out.report.get(0)).readLines().first().contains("Sample,n_genes,n_cells,mean_genes_by_counts,mean_cells_by_counts,mean_total_nnz_counts,mean_percent_mito")
+        }
+    }
+}

--- a/tests/modules/local/util/main.nf.test
+++ b/tests/modules/local/util/main.nf.test
@@ -32,7 +32,22 @@ nextflow_process {
     script  "modules/local/util/main.nf"
     process "QC"
 
-    test("Should run QC successfully with local atlas") {
+    setup {
+        run("CREATE_TEST_ADATA") {
+            script "tests/data/create_adata.nf"
+            params {
+                max_cpus = 2
+                max_memory = '4 GB'
+            }
+            process {
+            """
+            input[0] = 2
+            """
+            }
+        }
+    }
+
+    test("Should run QC successfully with test data") {
 
         tag "process"
         tag "qc"
@@ -42,11 +57,10 @@ nextflow_process {
                 max_memory = '4.GB'
                 max_cpus   = 1
             }
+            
             process {
                 """
-                input[0] = [[id:"atlas"],
-                            file("${projectDir}/tests/data/atlas_small.h5ad"),
-                            "atlas_input"]
+                input[0] = CREATE_TEST_ADATA.out.adata.map{ it -> [[id:"sample"], it[1], "atlas_input"] }
                 """
             }
         }

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -4,18 +4,15 @@ nextflow_process{
     process 'STAPLE_XSAMPLE'
 
     setup {
-        run("SQUIDPY_SPATIAL_PLOTS"){
-            script "modules/local/squidpy/main.nf"
+        run("CREATE_TEST_ADATA") {
+            script "tests/data/create_adata.nf"
             params {
                 max_cpus = 2
                 max_memory = '4 GB'
             }
             process {
             """
-            input[0] = Channel.from(
-                            [[id:"sample"], file("${projectDir}/tests/data/rctd.h5ad")],
-                            [[id:"sample2"], file("${projectDir}/tests/data/rctd.h5ad")]
-                        )
+            input[0] = 10
             """
             }
         }
@@ -29,7 +26,7 @@ nextflow_process{
         when {
             process {
                 """
-                input[0] = SQUIDPY_SPATIAL_PLOTS.out.adata.map{ it -> it[1] }.collect()
+                input[0] = CREATE_TEST_ADATA.out.adata.collect()
                 """
             }
         }

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -1,0 +1,41 @@
+nextflow_process{
+    name    'xsample'
+    script  'modules/local/xsample/main.nf'
+    process 'STAPLE_XSAMPLE'
+
+    setup {
+        run("SQUIDPY_SPATIAL_PLOTS"){
+            script "modules/local/squidpy/main.nf"
+            params {
+                max_cpus = 2
+                max_memory = '4 GB'
+            }
+            process {
+            """
+            input[0] = Channel.from(
+                            [[id:"sample"], file("${projectDir}/tests/data/rctd.h5ad")],
+                            [[id:"sample2"], file("${projectDir}/tests/data/rctd.h5ad")]
+                        )
+            """
+            }
+        }
+    }
+
+    test("Run Xsample with multiple samples") {
+
+        tag     'xsample'
+        tag     'xsample-spatial'
+
+        when {
+            process {
+                """
+                input[0] = SQUIDPY_SPATIAL_PLOTS.out.adata.map{ it -> it[1] }.collect()
+                """
+            }
+        }
+
+        then {
+            assert process.success
+        }
+    }
+}

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -34,7 +34,7 @@ nextflow_process{
         then {
             assert process.success
             assert process.out.versions
-            assert process.out.mqc
+            assert process.out.multiqc_files
         }
     }
 }

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -1,5 +1,5 @@
 nextflow_process{
-    name    'xsample'
+    name    'Test xsample'
     script  'modules/local/xsample/main.nf'
     process 'STAPLE_XSAMPLE'
 

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -33,6 +33,8 @@ nextflow_process{
 
         then {
             assert process.success
+            assert process.out.versions
+            assert process.out.mqc
         }
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to the quality control (QC) metrics calculation in the pipeline, updates the pipeline version, and adds new and expanded test coverage for local modules. The most significant changes include enhanced mitochondrial content calculation in QC, version bump, and new tests for both QC and xsample processes.

**Quality Control Improvements:**
* The QC step now calculates mitochondrial gene content by adding a `"mito"` flag to `adata.var` and using it in `sc.pp.calculate_qc_metrics`, with the mean percent mitochondrial content included in the report (`modules/local/util/main.nf`).

**Testing Enhancements:**
* Added a new test for the QC process to ensure the updated metrics (including mitochondrial content) are correctly computed and reported (`tests/modules/local/util/main.nf.test`).
* Introduced a new test for the `xsample` process, including setup with spatial plots and validation for handling multiple samples (`tests/modules/local/xsample/main.nf.test`).

**Pipeline Versioning:**
* Bumped the pipeline version from `2.2.6` to `2.2.7` in `nextflow.config` to reflect these updates.