### PR TITLE
add umi_min, close #151

### DIFF
--- a/modules/local/rctd/templates/rctd.r
+++ b/modules/local/rctd/templates/rctd.r
@@ -12,6 +12,7 @@ adata_st_path <- '${adata_st}'
 ncores <- ${task.cpus}
 outdir <- '${prefix}'
 process <- '${task.process}'
+umi_min <- ${params.umi_min}
 
 set.seed(${params.seed})
 
@@ -98,14 +99,18 @@ gc()
 
 message('run rctd')
 rctd_res <- tryCatch({
-  spacexr::run.RCTD(spacexr::create.RCTD(spatialRNA=query, reference=ref, max_cores = ncores),
-                    doublet_mode = doublet_mode)
+  spacexr::run.RCTD(
+    spacexr::create.RCTD(spatialRNA=query, reference=ref,
+                         max_cores = ncores, UMI_min = umi_min),
+    doublet_mode = doublet_mode)
 }, error = function(e) {
   message('RCTD threw error: "',e[["message"]],'"')
   if (grepl(pattern = "UMI_min_sigma", x = e[["message"]])) {
     message('RCTD error caught, retrying with UMI_min_sigma=1')
-    spacexr::run.RCTD(spacexr::create.RCTD(spatialRNA=query, reference=ref, max_cores = ncores, UMI_min_sigma = 1),
-                      doublet_mode = doublet_mode)
+    spacexr::run.RCTD(
+      spacexr::create.RCTD(spatialRNA=query, reference=ref, max_cores = ncores, 
+                           UMI_min_sigma = 1, UMI_min = umi_min),
+      doublet_mode = doublet_mode)
   } else {
     stop("Could not catch the error")
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,6 +81,7 @@ params {
 
     //rctd options
     doublet_mode                         = 'full'
+    umi_min                              = 100
 
     // Deconvolution / cell typing tools
     deconvolve {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -199,7 +199,6 @@
                     "type": "boolean",
                     "fa_icon": "far fa-check-circle",
                     "description": "Validation of parameters fails when an unrecognised parameter is found.",
-                    "default": false,
                     "hidden": true,
                     "help_text": "By default, when an unrecognised parameter is found, it returns a warinig."
                 },
@@ -393,6 +392,11 @@
         "sq_gr_ligrec_interactions_params": {
             "type": "string",
             "description": "JSON string specifying database for sq.gr.ligrec() (e.g., '{\"resources\": \"CellPhoneDB\"}')."
+        },
+        "umi_min": {
+            "type": "integer",
+            "default": 100,
+            "description": "min UMI counts, passed to RCTD UMI_min parameter"
         }
     }
 }

--- a/tests/modules/local/rctd/rctd.nf.test
+++ b/tests/modules/local/rctd/rctd.nf.test
@@ -13,6 +13,7 @@ nextflow_process {
             params {
                 max_memory = '8.GB'
                 max_cpus   = 2
+                outdir = 'output'
             }
             process {
                 """
@@ -42,6 +43,37 @@ nextflow_process {
                 max_memory = '8.GB'
                 max_cpus   = 2
                 doublet_mode = 'doublet'
+                outdir = 'output'
+            }
+            process {
+                """
+                input[0] = [[id:"sample"],
+                            file("${projectDir}/tests/data/atlas_small.h5ad"),
+                            file("${projectDir}/tests/data/adata_matched.h5ad")]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.rctd_cell_types
+            assert process.out.rctd_object
+            assert process.out.versions
+        }
+    }
+    
+    test("Should run RCTD with custom UMI_min") {
+
+        tag "process"
+        tag "rctd"
+        tag "visiumhd"
+
+        when {
+            params {
+                max_memory = '8.GB'
+                max_cpus   = 2
+                umi_min = 1
+                outdir = 'output'
             }
             process {
                 """


### PR DESCRIPTION
This pull request introduces support for configuring the minimum UMI count (`UMI_min`) parameter for the RCTD tool, making it easier to control filtering of low-quality spots in spatial transcriptomics analysis. The changes add the `umi_min` parameter to configuration, pipeline logic, and testing.

**Parameterization of RCTD minimum UMI count:**

* Added `umi_min` as a configurable parameter in `nextflow.config` and exposed it in `nextflow_schema.json` with a default value of 100. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR84) [[2]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R395-R399)
* Passed the `umi_min` parameter to the RCTD R script (`rctd.r`), ensuring it is used when creating the RCTD object and also when retrying after a UMI_min_sigma error. [[1]](diffhunk://#diff-12b83183fc95473a41470a140d5decb27c0d2247b4b46d97e02deeb9707bb389R15) [[2]](diffhunk://#diff-12b83183fc95473a41470a140d5decb27c0d2247b4b46d97e02deeb9707bb389L101-R112)

**Testing enhancements:**

* Updated the RCTD module tests to include scenarios with custom `umi_min` values, verifying that the pipeline supports and correctly handles this parameter.

No unrelated or breaking changes are included in this pull request.