### PR TITLE
init centrality measures

### DIFF
--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -248,19 +248,19 @@ def centrality_reports(adatas, spotlight=None, scores=None, uns_key='cell_type_c
     for score in scores:
         sample_dict = {}
         for adata in adatas:
-                if uns_key not in adata.uns or score not in adata.uns[uns_key]:
-                    continue
-                centrality_scores = adata.uns[uns_key][score]
-                available_cell_types = adata.obs['cell_type'].cat.categories.tolist()
-                if spotlight:
-                    cell_types = [cell_type for cell_type in available_cell_types if cell_type in spotlight]
-                else:
-                    cell_types = available_cell_types
-                centrality_dict = {}
-                for i, cell_type in enumerate(available_cell_types):
-                    if cell_type in cell_types:
-                        centrality_dict[cell_type] = centrality_scores.iloc[i]
-                sample_dict[adata.obs['id'].unique()[0]] = centrality_dict
+            if uns_key not in adata.uns or score not in adata.uns[uns_key]:
+                continue
+            centrality_scores = adata.uns[uns_key][score]
+            available_cell_types = adata.obs['cell_type'].cat.categories.tolist()
+            if spotlight:
+                cell_types = [cell_type for cell_type in available_cell_types if cell_type in spotlight]
+            else:
+                cell_types = available_cell_types
+            centrality_dict = {}
+            for i, cell_type in enumerate(available_cell_types):
+                if cell_type in cell_types:
+                    centrality_dict[cell_type] = centrality_scores.iloc[i]
+            sample_dict[adata.obs['id'].unique()[0]] = centrality_dict
 
         mqc_report = {
             "id": f"{score}",

--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -139,6 +139,44 @@ def neighbors_report(adatas, spotlight=None):
     }
     return mqc_report
 
+def centrality_reports(adatas, spotlight=None, scores=None, uns_key='cell_type_centrality_scores'):
+    #separately for each score as multiqc does not support data_labels for heatmaps
+    memos = {
+        'closeness_centrality': "This graph measure reflects how close the group is to other nodes.",
+        'average_clustering': "This graph measure shows the degree to which nodes cluster together.",
+        'degree_centrality': "This graph measure is the fraction of non-group members connected to group members"
+    }
+
+    adatas_scores = [a.uns[uns_key].keys().tolist() for a in adatas if uns_key in a.uns]
+    all_scores = set.union(*[set(s) for s in adatas_scores])
+    if scores:
+        scores = all_scores.intersection(set(scores))
+    else:
+        scores = all_scores
+    reports = {}
+    for score in scores:
+        sample_dict = {}
+        for adata in adatas:
+                centrality_scores = adata.uns[uns_key][score]
+                cell_types = adata.obs['cell_type'].cat.categories.tolist()
+                centrality_dict = {}
+                for i, cell_type in enumerate(cell_types):
+                    centrality_dict[cell_type] = centrality_scores.iloc[i]
+                sample_dict[adata.obs['id'].unique()[0]] = centrality_dict
+
+        mqc_report = {
+            "id": f"{score}",
+            "description": memos.get(score, f"Centrality score {score} across samples"),
+            "plot_type": "table",
+            "pconfig": {
+                "ylab": "Sample",
+                "xlab": "Cell type",
+                "title": f"{score} centrality score across samples"
+            },
+            "data": sample_dict
+        }
+        reports[score] = mqc_report
+    return reports
 
 
 def plot_hist(df_pair, title=None, save=True):
@@ -232,11 +270,22 @@ if __name__ == '__main__':
 
     # generate neighbors report
     try:
+        log.info("Generating neighbors report.")
         neighbors = neighbors_report(adatas, spotlight=spotlight)
         with open(f"{mqc_reports_dir}/neighbors_mqc.json","w") as f:
             json.dump(neighbors, f, indent=4)
     except Exception as e:
         log.warning(f"Could not generate neighbors report: {e}")
+
+    # generate centrality report - separately
+    try:
+        log.info("Generating centrality report.")
+        centrality = centrality_reports(adatas, spotlight=spotlight)
+        for score, report in centrality.items():
+            with open(f"{mqc_reports_dir}/{score}_mqc.json","w") as f:
+                json.dump(report, f, indent=4)
+    except Exception as e:
+        log.warning(f"Could not generate centrality report for score {score}: {e}")
 
     # print versions now because later may be too late
     versions()

--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -148,6 +148,8 @@ def centrality_reports(adatas, spotlight=None, scores=None, uns_key='cell_type_c
     }
 
     adatas_scores = [a.uns[uns_key].keys().tolist() for a in adatas if uns_key in a.uns]
+    if not adatas_scores:
+        return {}
     all_scores = set.union(*[set(s) for s in adatas_scores])
     if scores:
         scores = all_scores.intersection(set(scores))
@@ -157,11 +159,18 @@ def centrality_reports(adatas, spotlight=None, scores=None, uns_key='cell_type_c
     for score in scores:
         sample_dict = {}
         for adata in adatas:
+                if uns_key not in adata.uns or score not in adata.uns[uns_key]:
+                    continue
                 centrality_scores = adata.uns[uns_key][score]
-                cell_types = adata.obs['cell_type'].cat.categories.tolist()
+                available_cell_types = adata.obs['cell_type'].cat.categories.tolist()
+                if spotlight:
+                    cell_types = [cell_type for cell_type in available_cell_types if cell_type in spotlight]
+                else:
+                    cell_types = available_cell_types
                 centrality_dict = {}
-                for i, cell_type in enumerate(cell_types):
-                    centrality_dict[cell_type] = centrality_scores.iloc[i]
+                for i, cell_type in enumerate(available_cell_types):
+                    if cell_type in cell_types:
+                        centrality_dict[cell_type] = centrality_scores.iloc[i]
                 sample_dict[adata.obs['id'].unique()[0]] = centrality_dict
 
         mqc_report = {
@@ -285,7 +294,7 @@ if __name__ == '__main__':
             with open(f"{mqc_reports_dir}/{score}_mqc.json","w") as f:
                 json.dump(report, f, indent=4)
     except Exception as e:
-        log.warning(f"Could not generate centrality report for score {score}: {e}")
+        log.warning(f"Could not generate centrality report: {e}")
 
     # print versions now because later may be too late
     versions()

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -62,7 +62,7 @@ def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample'):
     #simulate staple behavior of added metadata from samplesheet
     adata.uns['added_metadata_fields'] = ['response', 'id']
 
-    #add centraloty measures
+    #add centrality measures
     sq.gr.centrality_scores(adata, cluster_key='cell_type')
 
     return adata

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -62,6 +62,9 @@ def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample'):
     #simulate staple behavior of added metadata from samplesheet
     adata.uns['added_metadata_fields'] = ['response', 'id']
 
+    #add centraloty measures
+    sq.gr.centrality_scores(adata, cluster_key='cell_type')
+
     return adata
 
 

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -94,6 +94,9 @@ def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample', with_metadata
     adata.uns['ligrec_means'] = ligrec_means
     adata.uns['ligrec_pvalues'] = ligrec_pvalues
 
+    # recompute interactions using the final cell_type categories so that
+    # the stored interaction matrix and centrality scores stay in sync
+    sq.gr.interaction_matrix(adata, cluster_key='cell_type')
 
     #add centrality measures
     sq.gr.centrality_scores(adata, cluster_key='cell_type')

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -28,9 +28,9 @@ nextflow_process{
         when {
             params {
                 outdir = 'output'
-                analyze{
+                analyze {
                     xsample = true
-                    filter = 0.99
+                    filter = 1
                     show_top = 100
                 }
             }
@@ -60,9 +60,9 @@ nextflow_process{
         when {
             params {
                 outdir = 'output'
-                analyze{
+                analyze {
                     xsample  = true
-                    filter   = 1 // set high to get some significant genes for testing purposes
+                    filter   = 1
                     pb_vars  = 'id,response'
                     show_top = 100
                 }
@@ -92,7 +92,7 @@ nextflow_process{
         when {
             params {
                 outdir = 'output'
-                analyze{
+                analyze {
                     xsample = true
                     filter = 1
                     show_top = 100
@@ -103,9 +103,6 @@ nextflow_process{
                 """
                 input[0] = CREATE_TEST_ADATA.out.adata.collect()
                 """
-            }
-            params {
-                outdir = "output"
             }
         }
 

--- a/tests/modules/local/xsample/main.nf.test
+++ b/tests/modules/local/xsample/main.nf.test
@@ -29,12 +29,18 @@ nextflow_process{
                 input[0] = CREATE_TEST_ADATA.out.adata.collect()
                 """
             }
+            params {
+                outdir = "output"
+            }
         }
 
         then {
             assert process.success
             assert process.out.versions
             assert process.out.multiqc_files
+            assert file("${outputDir}/staple/reports/mqc/average_clustering_mqc.json").exists()
+            assert file("${outputDir}/staple/reports/mqc/closeness_centrality_mqc.json").exists()
+            assert file("${outputDir}/staple/reports/mqc/degree_centrality_mqc.json").exists()
         }
     }
 }


### PR DESCRIPTION
This pull request adds functionality to generate and report centrality measures for cell types across samples within the `xsample` analysis pipeline. The main changes include implementing a new function for centrality reports, integrating this reporting into the main workflow, and updating test data creation to include centrality scores.

**Centrality reporting enhancements:**

* Added a new function `centrality_reports` in `xsample.py` to compute and format centrality measures (closeness centrality, average clustering, and degree centrality) for each cell type across samples, returning results in a MultiQC-compatible format.
* Integrated the centrality report generation into the main workflow, saving a separate JSON report for each centrality score and logging the process.

**Testing improvements:**

* Updated the test data generation in `create_adata.py` to compute and include centrality measures using `sq.gr.centrality_scores`, ensuring centrality reporting can be tested.