### PR TITLE
improve NA cell_type handling, close #158

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -16,7 +16,7 @@ custom_data:
   atlas:
     plot_type: 'table'
     section_name: 'Atlas Summary'
-    description: 'Summary of the cells and genes in the atlas. If same atlas is used for multiple samples, table rows will be repeated.'
+    description: 'Summary of the cells and genes in the atlas.'
   atlas_ct:
     parent: 'atlas'
     plot_type: 'table'
@@ -34,7 +34,7 @@ custom_data:
     parent: 'deconvolved'
     plot_type: 'table'
     section_name: 'Output Cell Types'
-    description: 'Assigned cell types based on deconvolution / cell typing results.'
+    description: 'Assigned cell types based on deconvolution / cell typing results. Unassigned counts appear in a nameless column.'
   deconvolved_probs:
     parent: 'deconvolved'
     plot_type: 'table'

--- a/modules/local/squidpy/templates/spatial.py
+++ b/modules/local/squidpy/templates/spatial.py
@@ -13,7 +13,7 @@ sample = "${sample}"
 out = "${prefix}"
 process = "${task.process}"
 cell_type = "cell_type"
-na_as_value = "${params.na_as_value}"
+na_as_value = "${params.na_as_value}".lower() == 'true'
 seed = ${params.seed}
 nperms = ${params.sq_gr_spatial_autocorr_nperms}
 n_jobs = ${task.cpus}

--- a/modules/local/util/main.nf
+++ b/modules/local/util/main.nf
@@ -200,7 +200,7 @@ if outname in ["atlas_counts", "adata_counts"]:
     else:
         cell_type_col = "${params.ref_scrna_type_col}"
     if cell_type_col in adata.obs.columns:
-        ct_counts = adata.obs[cell_type_col].value_counts()
+        ct_counts = adata.obs[cell_type_col].value_counts(dropna=False)
         ct_counts.columns = ["cell_type", "n_cells"]
         ct_counts = pd.DataFrame(ct_counts).transpose()
         ct_counts.insert(0, "Sample", sample)

--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -117,8 +117,13 @@ def pseudobulk_adatas(adatas, vars=None, only_spatial=False):
                 if adata.obs[var].isna().any():
                     log.warning(f"NA values found in grouping variable {var} for sample {adata.obs['id'].unique()[0]}.\
                         Replacing NA with 'NA' string for pseudobulk grouping.")
-                    adata.obs[var] = adata.obs[var].cat.add_categories('NA')
-                    adata.obs[var] = adata.obs[var].fillna('NA')
+                    series = adata.obs[var]
+                    if isinstance(series.dtype, pd.CategoricalDtype):
+                        if 'NA' not in series.cat.categories:
+                            series = series.cat.add_categories(['NA'])
+                        adata.obs[var] = series.fillna('NA')
+                    else:
+                        adata.obs[var] = series.astype(object).fillna('NA')
         adata = adata.to_memory()
         if only_spatial:
             adata = adata[:, adata.var['spatially_variable']==True]

--- a/modules/local/xsample/templates/xsample.py
+++ b/modules/local/xsample/templates/xsample.py
@@ -111,6 +111,14 @@ def pseudobulk_adatas(adatas, vars=None, only_spatial=False):
     # if only_spatial, select only genes with spatially variable expression
     pb_adatas = []
     for adata in adatas:
+        # check that there are no NA values in grouping
+        if vars is not None:
+            for var in vars:
+                if adata.obs[var].isna().any():
+                    log.warning(f"NA values found in grouping variable {var} for sample {adata.obs['id'].unique()[0]}.\
+                        Replacing NA with 'NA' string for pseudobulk grouping.")
+                    adata.obs[var] = adata.obs[var].cat.add_categories('NA')
+                    adata.obs[var] = adata.obs[var].fillna('NA')
         adata = adata.to_memory()
         if only_spatial:
             adata = adata[:, adata.var['spatially_variable']==True]

--- a/nextflow.config
+++ b/nextflow.config
@@ -278,7 +278,10 @@ profiles {
         }
         process {
             executor = 'slurm'
-            clusterOptions = { "-A ${params.slurm_account}" }
+            clusterOptions = {
+                def account = params.slurm_account?.toString()?.trim()
+                account ? "-A ${account}" : ''
+            }
             errorStrategy =  'retry'
             maxRetries = 3
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -76,7 +76,7 @@ params {
     sq_gr_ligrec_interactions_params        = ''   //for example, {"resources": "CellPhoneDB"}
     sq_gr_spatial_autocorr_nperms           = 0    //number of permutations for Moran's I
     sq_pl_ligrec_max_interactions           = 25   //max interactions to plot
-    na_as_value                             = 'NA' //replace NA in cell type with this, False to keep as NA
+    na_as_value                             = true //replace NA in cell type with text, False to keep as NA
 
     //rctd options
     doublet_mode                         = 'full'
@@ -273,9 +273,12 @@ profiles {
             autoMounts = true
             pullTimeout = '60m'
         }
+        params {
+            slurm_account = null
+        }
         process {
             executor = 'slurm'
-            clusterOptions = "-x juggernaut"
+            clusterOptions = { "-A ${params.slurm_account}" }
             errorStrategy =  'retry'
             maxRetries = 3
         }

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -102,7 +102,8 @@ def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample', with_metadata
     sq.gr.centrality_scores(adata, cluster_key='cell_type')
 
     #set a small number of cell types to NA for testing NA handling
-    na_indices = np.random.choice(adata.obs.shape[0], size=10, replace=False)
+    na_sample_size = min(10, adata.obs.shape[0])
+    na_indices = np.random.choice(adata.obs.shape[0], size=na_sample_size, replace=False)
     adata.obs.loc[adata.obs.index[na_indices], 'cell_type'] = np.nan
 
     return adata

--- a/tests/data/templates/create_adata.py
+++ b/tests/data/templates/create_adata.py
@@ -101,6 +101,10 @@ def make_one_adata(n=25, m=1000, pct_mito=0.1, sample_id='sample', with_metadata
     #add centrality measures
     sq.gr.centrality_scores(adata, cluster_key='cell_type')
 
+    #set a small number of cell types to NA for testing NA handling
+    na_indices = np.random.choice(adata.obs.shape[0], size=10, replace=False)
+    adata.obs.loc[adata.obs.index[na_indices], 'cell_type'] = np.nan
+
     return adata
 
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to handling missing (NA) values in cell type annotations, configuration flexibility for SLURM profiles, and clearer documentation in configuration files. The main focus is on ensuring robust NA handling throughout the data processing and providing users with more control over SLURM job submissions.

**NA Handling and Data Processing Improvements:**

* Ensured that missing (NA) values in cell type columns are consistently included in cell type counts by setting `dropna=False` when calling `value_counts` in `main.nf`. This change guarantees that NA values are not omitted from summary statistics.
* Enhanced the pseudobulk generation logic in `xsample.py` to automatically detect and replace NA values in grouping variables with the string `'NA'`, ensuring that samples with missing groupings are handled gracefully and consistently.
* Updated the test data generator in `create_adata.py` to randomly assign some cell type values to NA, enabling more robust testing of NA handling throughout the pipeline.

**Configuration and Documentation Updates:**

* Changed the `na_as_value` parameter in `nextflow.config` and its usage in `spatial.py` to a boolean, simplifying its interpretation and making NA replacement behavior clearer and more consistent. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL79-R79) [[2]](diffhunk://#diff-60ee404162af940aa7895555eb1eb2d4d1d9f2cd03c1305cceb0398f7e0ce4daL16-R16)
* Improved documentation in `multiqc_config.yml` by clarifying the description for the atlas summary and specifying how unassigned cell type counts appear in output tables. [[1]](diffhunk://#diff-5b56e1387e322ba70ed9af7ec3cddc1f4e0e1b73459fc77fe0fe261223dcec55L19-R19) [[2]](diffhunk://#diff-5b56e1387e322ba70ed9af7ec3cddc1f4e0e1b73459fc77fe0fe261223dcec55L37-R37)

**SLURM Profile Flexibility:**

* Added support for specifying a SLURM account in the `slurm` profile. The `clusterOptions` are now dynamically set based on the presence of `params.slurm_account`, allowing for greater flexibility in job submission.