### PR TITLE
161 strict syntax default from nextflow v26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ omnipathr*
 .Rproj.user/
 .idea/
 venv/
+.nf-test/

--- a/main.nf
+++ b/main.nf
@@ -1,9 +1,9 @@
 #!/usr/bin/env nextflow
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    btc/spatial
+    btc/staple
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Github : https://github.com/btc/spatial
+    Github : https://github.com/break-through-cancer/staple
 ----------------------------------------------------------------------------------------
 */
 
@@ -16,22 +16,6 @@ nextflow.enable.dsl = 2
 */
 
 include { validateParameters; paramsHelp } from 'plugin/nf-validation'
-
-// Print help message if needed
-if (params.help) {
-    def logo = NfcoreTemplate.logo(workflow, params.monochrome_logs)
-    def citation = '\n' + WorkflowMain.citation(workflow) + '\n'
-    def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
-    log.info logo + paramsHelp(command) + citation + NfcoreTemplate.dashedLine(params.monochrome_logs)
-    System.exit(0)
-}
-
-// Validate input parameters
-if (params.validate_params) {
-    //validateParameters()
-}
-
-WorkflowMain.initialise(workflow, params, log)
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/subworkflows/local/deconvolve/deconvolve_bayestme.nf
+++ b/subworkflows/local/deconvolve/deconvolve_bayestme.nf
@@ -8,18 +8,18 @@ workflow BAYESTME {
         ch_input // Channel of tuples: (meta, adata_sc, adata_spatial, coda_annotations)
 
     main:
-        ch_input.map { [it.meta, params.should_run_bleeding_correction] }.tap { should_run_bleeding_correction }
+        ch_input.map { it -> [it.meta, params.should_run_bleeding_correction] }.tap { should_run_bleeding_correction }
 
 
         // construct bayestme input from params
-        ch_btme = ch_input.map { [it.meta, it.data_directory] }
+        ch_btme = ch_input.map { it -> [it.meta, it.data_directory] }
 
         BAYESTME_LOAD_SPACERANGER( ch_btme )
         ch_adata = BAYESTME_LOAD_SPACERANGER.out.adata
         versions = BAYESTME_LOAD_SPACERANGER.out.versions
 
         filter_genes_input = ch_adata
-        .map { tuple(
+        .map { it -> tuple(
             it[0],                          // sample_name
             it[1],                          // adata
             true,                           // filter_ribosomal_genes
@@ -33,28 +33,28 @@ workflow BAYESTME {
 
         BAYESTME_FILTER_GENES.out.adata_filtered
             .join( should_run_bleeding_correction )
-            .filter { it[-1] == true }
-            .map { tuple(it[0], it[1]) }
+            .filter { it -> it[-1] == true }
+            .map { it -> tuple(it[0], it[1]) }
             .tap { bleeding_correction_input }
 
         BAYESTME_FILTER_GENES.out.adata_filtered
             .join( should_run_bleeding_correction )
-            .filter { it[-1] == false }
-            .map { tuple(it[0], 
-                         it[1], 
-                         params.n_cell_types, 
-                         params.bayestme_spatial_smoothing_parameter,
-                         []) }
+            .filter { it -> it[-1] == false }
+            .map { it -> tuple(it[0], 
+                               it[1], 
+                               params.n_cell_types, 
+                               params.bayestme_spatial_smoothing_parameter,
+                               []) }
             .tap { not_bleed_corrected_deconvolution_input }
 
         BAYESTME_BLEEDING_CORRECTION( bleeding_correction_input )
         versions = versions.mix(BAYESTME_BLEEDING_CORRECTION.out.versions)
 
         deconvolution_input = BAYESTME_BLEEDING_CORRECTION.out.adata_corrected
-            .join( ch_input.map { tuple(it[0], it[2]) } )
-            .map { tuple(it[0], it[1], it[2], params.bayestme_spatial_smoothing_parameter) }
+            .join( ch_input.map { it -> tuple(it[0], it[2]) } )
+            .map { it -> tuple(it[0], it[1], it[2], params.bayestme_spatial_smoothing_parameter) }
             .concat( not_bleed_corrected_deconvolution_input )
-            .map { tuple(it[0], //meta
+            .map { it -> tuple(it[0], //meta
                         it[1], //dataset_filtered
                         it[2], //n_cell_types
                         it[3], //smoothing_parameter
@@ -64,7 +64,6 @@ workflow BAYESTME {
 
         BAYESTME_DECONVOLUTION( deconvolution_input )
         versions = versions.mix(BAYESTME_DECONVOLUTION.out.versions)
-
         // Output the deconvolved data
         ch_deconvolved = BAYESTME_DECONVOLUTION.out.adata_deconvolved
 

--- a/subworkflows/local/deconvolve/deconvolve_cogaps.nf
+++ b/subworkflows/local/deconvolve/deconvolve_cogaps.nf
@@ -6,46 +6,44 @@ include { CELL_TYPES_FROM_COGAPS as COGAPS_CELL_TYPES } from '../../../modules/l
 
 workflow COGAPS {
     take:
-        ch_adata // Channel of [meta, adata]
+        ch_adata // channel of [meta, adata]
 
     main:
 
-    def patterns = params.npatterns.split(',').collect { it.toInteger() }
-    ch_patterns = Channel.from(patterns)
-    versions = Channel.empty()
+    def patterns = params.npatterns.split(',').collect { it -> it.toInteger() }
+    ch_patterns = channel.from(patterns)
+    versions = channel.empty()
 
     //example channel with cparams
-    ch_fixed_params = Channel.of([niterations: params.niterations, sparse: params.sparse, distributed: params.distributed, nsets:params.nsets, nthreads:1])
+    ch_fixed_params = channel.of([niterations: params.niterations, sparse: params.sparse, distributed: params.distributed, nsets:params.nsets, nthreads:1])
 
     ch_cparams = ch_patterns
       .combine(ch_fixed_params)
-      .map { tuple([id:it[0].toString(), npatterns:it[0], niterations:it[1].niterations, sparse:it[1].sparse, distributed:it[1].distributed, nsets:it[1].nsets, nthreads:it[1].nthreads]) }
+      .map { it -> tuple([id:it[0].toString(), npatterns:it[0], niterations:it[1].niterations, sparse:it[1].sparse, distributed:it[1].distributed, nsets:it[1].nsets, nthreads:it[1].nthreads]) }
 
     // convert adata to dgCMatrix
     COGAPS_ADATA2DGC(ch_adata)
-    ch_versions = versions.mix(COGAPS_ADATA2DGC.out.versions)
+    versions = versions.mix(COGAPS_ADATA2DGC.out.versions)
 
 
     // preprocess dgCMatrix
     ch_preprocess = COGAPS_ADATA2DGC.out.dgCMatrix
-      .map { tuple(it[0], it[1]) }
+      .map { it -> tuple(it[0], it[1]) }
 
     COGAPS_PREPROCESS(ch_preprocess)
-    ch_versions = ch_versions.mix(COGAPS_PREPROCESS.out.versions)
+    versions = versions.mix(COGAPS_PREPROCESS.out.versions)
 
     ch_input = COGAPS_PREPROCESS.out.dgCMatrix
-      .map { tuple(it[0], it[1]) }
+      .map { it -> tuple(it[0], it[1]) }
       .combine(ch_cparams)
 
     COGAPS_MAIN(ch_input)
-    ch_versions = ch_versions.mix(COGAPS_MAIN.out.versions)
-    ch_cogaps = COGAPS_MAIN.out.cogapsResult.map { tuple(it[0], it[1]) }
+    versions = versions.mix(COGAPS_MAIN.out.versions)
+    ch_cogaps = COGAPS_MAIN.out.cogapsResult.map { it -> tuple(it[0], it[1]) }
 
     COGAPS_CELL_TYPES(ch_cogaps)
-    ch_versions = ch_versions.mix(COGAPS_CELL_TYPES.out.versions)
-
-    ch_deconvolved = COGAPS_CELL_TYPES.out.cogaps_cell_types
-      .map { tuple(it[0], it[1]) }
+    versions = versions.mix(COGAPS_CELL_TYPES.out.versions)
+    ch_deconvolved = COGAPS_CELL_TYPES.out.cogaps_cell_types.map { it -> tuple(it[0], it[1]) }
 
     emit:
         ch_deconvolved

--- a/subworkflows/local/load_dataset.nf
+++ b/subworkflows/local/load_dataset.nf
@@ -98,8 +98,9 @@ workflow LOAD_DATASET {
 
         // match scRNA atlas to spatial data
         ATLAS_MATCH(ch_scrna.join( ch_adata ))
-        ch_matched_adata = ATLAS_MATCH.out.adata_matched
+        
         versions = versions.mix(ATLAS_MATCH.out.versions)
+        ch_matched_adata = ATLAS_MATCH.out.adata_matched
 
 
     emit:


### PR DESCRIPTION
This pull request primarily updates the naming and references throughout the pipeline to reflect a project rename, and makes several code style and consistency improvements in the Nextflow workflows. The changes focus on standardizing channel operations, improving code clarity, and ensuring proper initialization and output handling.

Project renaming and reference updates:
- Updated project name references from `btc/spatial` to `btc/staple` and updated the GitHub URL accordingly in `main.nf`.

Code clarity and consistency improvements:
- Refactored lambda expressions in channel operations to use explicit parameter syntax (`it -> ...`) for improved readability and consistency across `deconvolve_bayestme.nf` and `deconvolve_cogaps.nf`. [[1]](diffhunk://#diff-866f6479048a510e7b5ac6f221539b8f39664f410d7d32f0314f368388c7457dL11-R22) [[2]](diffhunk://#diff-866f6479048a510e7b5ac6f221539b8f39664f410d7d32f0314f368388c7457dL36-R43) [[3]](diffhunk://#diff-866f6479048a510e7b5ac6f221539b8f39664f410d7d32f0314f368388c7457dL54-R57) [[4]](diffhunk://#diff-77cc0eb916c7010d5be6a09643de1597028396729b377278ba2a5efb32e2f64bL9-R46)
- Standardized channel creation and usage by replacing `Channel` with `channel` (lowercase) and ensuring consistent variable initialization in `deconvolve_cogaps.nf`.
- Improved handling and assignment of output channels and version tracking variables to ensure correct workflow outputs and provenance in `deconvolve_cogaps.nf` and `load_dataset.nf`. [[1]](diffhunk://#diff-77cc0eb916c7010d5be6a09643de1597028396729b377278ba2a5efb32e2f64bL9-R46) [[2]](diffhunk://#diff-5564730f3370db8abbaae6505b81efb95dda1e9a518c54e5a0f0223e401496b5L101-R103)

Workflow initialization and help handling:
- Removed unused help and parameter validation code from `main.nf` to streamline workflow initialization.