### PR TITLE
use stricted typing, close #164

### DIFF
--- a/modules/local/rctd/templates/rctd.r
+++ b/modules/local/rctd/templates/rctd.r
@@ -50,13 +50,13 @@ if (is.null(adata_sc[["raw"]])) {
   message('no raw data, using X from adata_sc')
   gene_names <-rownames(adata_sc[["var"]])
   select_genes <- which(gene_names %in% names(top_genes))
-  counts_sc <- Matrix::t(adata_sc[["X"]][, select_genes - 1]) # -1 for 0-based index
+  counts_sc <- Matrix::t(adata_sc[["X"]][, select_genes - 1L]) # -1 for 0-based index
   rownames(counts_sc) <- gene_names[select_genes]
 } else {
   message('using raw.X from adata_sc')
   gene_names <- rownames(adata_sc[["raw"]][["var"]])
   select_genes <- which(gene_names %in% names(top_genes))
-  counts_sc <- Matrix::t(adata_sc[["raw"]][["X"]][, select_genes - 1]) # -1 for 0-based index
+  counts_sc <- Matrix::t(adata_sc[["raw"]][["X"]][, select_genes - 1L]) # -1 for 0-based index
   rownames(counts_sc) <- gene_names[select_genes]
 }
 

--- a/tests/modules/local/rctd/rctd.nf.test
+++ b/tests/modules/local/rctd/rctd.nf.test
@@ -91,4 +91,36 @@ nextflow_process {
             assert process.out.versions
         }
     }
+
+        test("Should run with filtered n_top_genes for RCTD") {
+
+        tag "process"
+        tag "rctd"
+        tag "filtered_n_top_genes"
+
+        when {
+            params {
+                max_memory = '8.GB'
+                max_cpus   = 2
+                deconvolve {
+                    n_top_genes = 100
+                }
+                outdir = 'output'
+            }
+            process {
+                """
+                input[0] = [[id:"sample"],
+                            file("${projectDir}/tests/data/atlas_small.h5ad"),
+                            file("${projectDir}/tests/data/adata_matched.h5ad")]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.rctd_cell_types
+            assert process.out.rctd_object
+            assert process.out.versions
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a minor bug fix in the RCTD R script and adds a new test case to the RCTD Nextflow test suite. The main changes are:

### Bug fix

* Updated the indexing in `rctd.r` to use `-1L` instead of `-1` for zero-based indexing, ensuring the correct integer type is used for subsetting matrices.

### Testing improvements

* Added a new test case in `rctd.nf.test` to verify that the RCTD process runs successfully when using a filtered number of top genes (`n_top_genes = 100`). This test checks for successful process completion and the presence of expected outputs.